### PR TITLE
Add options to dump base and segment URLs

### DIFF
--- a/src/ytpb/cli/__init__.py
+++ b/src/ytpb/cli/__init__.py
@@ -18,6 +18,8 @@ import toml
 from ytpb.cli.commands.capture import capture_group
 from ytpb.cli.commands.download import download_command
 from ytpb.cli.commands.mpd import mpd_group
+
+from ytpb.cli.common import suppress_output
 from ytpb.cli.options import config_options, logging_options
 from ytpb.config import (
     ALL_ALIASES,
@@ -50,7 +52,7 @@ class ContextObject:
     """This object is referenced as `ctx.obj`."""
 
     config: ConfigMap = field(default_factory=lambda: ConfigMap(DEFAULT_CONFIG))
-    original_stdout: TextIO = sys.stdout
+    original_stdout: TextIO = field(default_factory=lambda: sys.stdout)
 
 
 def load_config_into_context(ctx: click.Context, path: Path) -> dict:
@@ -110,7 +112,7 @@ def base_cli(
     ctx.default_map = ctx.obj.config["options"]
 
     if quiet:
-        sys.stdout = open(os.devnull, "w")
+        suppress_output()
 
     if report:
         debug = True

--- a/src/ytpb/cli/common.py
+++ b/src/ytpb/cli/common.py
@@ -1,4 +1,5 @@
 import email
+import os
 import sys
 import textwrap
 from datetime import datetime, timedelta
@@ -276,3 +277,7 @@ def resolve_output_path(output_path: Path) -> Path:
     resolved_path = Path(output_path).expanduser().resolve()
     resolved_path.parent.mkdir(parents=True, exist_ok=True)
     return resolved_path
+
+
+def suppress_output() -> None:
+    sys.stdout = open(os.devnull, "w")

--- a/src/ytpb/utils/url.py
+++ b/src/ytpb/utils/url.py
@@ -3,6 +3,7 @@ import time
 from urllib.parse import parse_qs, urlparse
 
 from ytpb.exceptions import BadCommandArgument
+from ytpb.types import SegmentSequence
 
 
 def normalize_video_url(video_url_or_id: str) -> str:
@@ -61,6 +62,10 @@ def build_video_url_with_id(video_id: str) -> str:
 def build_video_url_from_base_url(base_url: str) -> str:
     video_id = extract_id_from_base_url(base_url)
     return build_video_url_with_id(video_id)
+
+
+def build_segment_url(base_url: str, sq: SegmentSequence | str) -> str:
+    return f"{base_url.rstrip('/')}/sq/{sq}"
 
 
 def check_base_url_is_expired(base_url: str) -> bool:

--- a/tests/cli/test_download_command.py
+++ b/tests/cli/test_download_command.py
@@ -1305,3 +1305,35 @@ def test_report_option(
     # Then:
     assert result.exit_code == 0
     assert os.path.exists(tmp_path / "ytpb-20230326-000000.log")
+
+
+@freeze_time("2023-03-26T00:00:00+00:00")
+def test_dump_base_urls_option(
+    add_responses_callback_for_segment_urls,
+    ytpb_cli_invoke: Callable,
+    fake_info_fetcher: MagicMock,
+    stream_url: str,
+    audio_base_url: str,
+    video_base_url: str,
+    tmp_path: Path,
+) -> None:
+    with patch("ytpb.cli.common.YtpbInfoFetcher") as mock_fetcher:
+        mock_fetcher.return_value = fake_info_fetcher
+        result = ytpb_cli_invoke(
+            [
+                "--no-config",
+                "download",
+                "--no-cache",
+                "--interval",
+                "7959120/7959121",
+                "-af",
+                "itag eq 140",
+                "-vf",
+                "itag eq 244",
+                "--dump-base-urls",
+                stream_url,
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert result.output == f"{audio_base_url}\n{video_base_url}\n"

--- a/tests/cli/test_download_command.py
+++ b/tests/cli/test_download_command.py
@@ -1337,3 +1337,45 @@ def test_dump_base_urls_option(
 
     assert result.exit_code == 0
     assert result.output == f"{audio_base_url}\n{video_base_url}\n"
+
+
+@freeze_time("2023-03-26T00:00:00+00:00")
+def test_dump_segment_urls_option(
+    add_responses_callback_for_reference_base_url,
+    add_responses_callback_for_segment_urls,
+    ytpb_cli_invoke: Callable,
+    fake_info_fetcher: MagicMock,
+    stream_url: str,
+    audio_base_url: str,
+    video_base_url: str,
+    tmp_path: Path,
+) -> None:
+    add_responses_callback_for_reference_base_url()
+    add_responses_callback_for_segment_urls(
+        urljoin(audio_base_url, r"sq/\w+"),
+        urljoin(video_base_url, r"sq/\w+"),
+    )
+
+    with patch("ytpb.cli.common.YtpbInfoFetcher") as mock_fetcher:
+        mock_fetcher.return_value = fake_info_fetcher
+        result = ytpb_cli_invoke(
+            [
+                "--no-config",
+                "download",
+                "--no-cache",
+                "--interval",
+                "7959120/7959121",
+                "-af",
+                "itag eq 140",
+                "-vf",
+                "itag eq 244",
+                "--dump-segment-urls",
+                stream_url,
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert result.output == (
+        f"{audio_base_url.rstrip('/')}/sq/[7959120-7959121]\n"
+        f"{video_base_url.rstrip('/')}/sq/[7959120-7959121]\n"
+    )


### PR DESCRIPTION
This adds two options to the `download` command: `--dump-base-urls` and `--dump-segment-urls`, and closes #9.