### PR TITLE
Add support for resumable downloads

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -513,8 +513,10 @@ examples:
 Writing metadata tags
 =====================
 
-By default, metadata tags will be added to the output file by the ``ytpb
-download`` command.  Use the ``--no-metadata`` option to disable it.
+*Related command:* ``ytpb download``
+
+By default, metadata tags will be added to an output excerpt file. Use the
+``--no-metadata`` option to disable it.
 
 .. table:: Metadata tags overview
 
@@ -545,6 +547,50 @@ expected to be different in only two cases: if the boundary (start and end)
 points fall in gaps or the ``--no-cut`` option is requested. In the opposite
 cases, after accurate cut, they're supposed to be identical.
 
+Saving segment files
+====================
+
+*Related command:* ``ytpb download``
+
+After merging downloaded segment files to make an excerpt, the segments will be
+deleted. Do you want to keep them? There are two options here.
+
+*First*, download an excerpt and keep segment files by using the ``-S /
+--keep-segments`` option::
+
+  $ ytpb download ... -S <STREAM>
+  ...
+  Success! Saved to 'Stream-Title_20240102T102030+00.mkv'.
+  ~ Segments are kept in 'Stream-Title_20240102T102030+00'.
+
+The download destination can be changed via ``--segments-output-dir``::
+
+  $ ytpb download ... -S --segments-output-dir segments <STREAM>
+  ...
+  Success! Saved to 'Stream-Title_20240102T102030+00.mkv'.
+  ~ Segments are kept in 'segments'.
+
+*Second*, download only segment files without merging them::
+
+  $ ytpb download ... --no-merge <STREAM>
+  ...
+  Success! Segments saved to 'Stream-Title_20240102T102030+00'.
+
+Resuming unfinished downloads
+=============================
+
+*Related command:* ``ytpb download``
+
+If a download gets interrupted for some reason (network problems, unhandled
+exceptions, aborting with ``Ctrl+C``, etc.), you can continue the unfinished
+download by execution of the same command again. Each run creates a resume file
+used to keep information needed for resumption, which is cleaned after
+successful completion. The commands are matched based on the following input
+option values: ``--interval``, ``--audio-format``, ``--video-format``, and
+``--segments-output-dir``. Resuming behavior can be disabled by the
+``--no-resume`` option to avoid: (1) creating a resume file at all and (2)
+continuing an existing download.
+
 Configuring
 ***********
 
@@ -569,9 +615,9 @@ Advanced usage
 Merging without cutting
 =======================
 
-By default, boundary segments are cutted to exact times during the merging step
-to produce an excerpt. It may take some time to re-encode boundary segments. If
-you don't need exact precision, it could be practical to omit cutting via the
+The boundary segments are cutted to exact times during the merging step to
+make an excerpt. It may take some time to re-encode boundary segments. If you
+don't need exact precision, it could be practical to omit cutting via the
 ``--no-cut`` option. In this case the accuracy will be slightly reduced, which
 will depend on the constant segment duration (or type of `live-streaming latency
 <https://support.google.com/youtube/answer/7444635?hl=en>`_): in the worst case,
@@ -580,44 +626,19 @@ latency) seconds.
 
 ::
 
-   $ ytpb download ... --no-cut
-
-Keep segment files
-==================
-
-By default, after merging downloaded segment files to produce an excerpt, the
-segments will be deleted. Do you want to keep them? There are two options here.
-
-*First*, download only segment files without merging them (it also implies
-another option, ``--no-cleanup``): ::
-
-  $ ytpb download ... --no-merge
-  ...
-  Success! Segments saved to /tmp/.../segments/.
-  notice: No cleanup enabled, check /tmp/.../
-
-Actually, it keeps not only segments (in ``/tmp/.../segments``) but some other
-auxiliary files in the run temporary directory (``/tmp/...``). Note that, in
-this case, the temporary directory shall be removed manually afterward.
-
-*Second*, download an excerpt and keep segment files: ::
-
-  $ ytpb download ... --no-cleanup
-  ...
-  notice: No cleanup enabled, check /tmp/.../
-
+   $ ytpb download ... --no-cut <STREAM>
 
 Running without downloading
 ===========================
 
-There is a dry run mode to run without downloading. It could be useful if you
-are not interested in having an output excerpt file: for example, you want to
-locate the desired segments or debug just the first steps (by combining a dry
-run mode with the logging options; see the subsection below).
+There is a dry run mode (``-X / --dry-run``) to run without downloading. It
+could be useful if you are not interested in having an output excerpt file: for
+example, you want to locate the rewind interval or debug just the first steps
+(by combining a dry run mode with the ``--debug`` global option).
 
-For example, just to locate start and end segments, use: ::
+For example, just to locate start and end moments, use::
 
-  $ ytpb download ... --dry-run
+  $ ytpb download ... --dry-run <STREAM>
   ...
   (<<) Locating start and end in the stream... done.
   Actual start: 25 Mar 2023 23:33:54 +0000, seq. 7959120
@@ -625,17 +646,18 @@ For example, just to locate start and end segments, use: ::
 
   notice: This is a dry run. Skip downloading and exit.
 
-It can be combined with the ``--no-cleanup`` option as well: ::
+It can be combined with the ``--keep-temp`` option to keep temporary
+files::
 
-  $ ytpb download ... --dry-run --no-cleanup
+  $ ytpb download ... --dry-run --keep-temp <STREAM>
 
 Using cache
 ===========
 
-Using cache helps to avoid getting info about videos and downloading MPEG-DASH
-manifest on every run. The cached files contain the info and the base URLs for
-segments, and are stored under ``XDG_CACHE_HOME/ytpb``. It's a default
-behavior. The cache expiration is defined by the base URLs expiration time. The
-``--no-cache`` option allows avoiding touching cache: no reading and
-writing. Another option, ``--force-update-cache``, exists to trigger cache
-update.
+Using cache helps to avoid getting information about videos and downloading
+MPEG-DASH manifest on every run. The cached files contain the basic information
+and the base URLs for segments, and are stored under
+``$XDG_CACHE_HOME/ytpb``. It's a default behavior. The cache expiration is
+defined by the segment base URLs expiration time. The ``--no-cache`` option allows
+avoiding touching cache: no reading and writing. Another option,
+``--force-update-cache``, exists to trigger cache update.

--- a/docs/package/usage.rst
+++ b/docs/package/usage.rst
@@ -173,6 +173,7 @@ download progress:
 .. code-block:: python
 
    from datetime import datetime, timedelta, timezone
+   from pathlib import Path
    from ytpb.actions.download import download_excerpt, RichProgressReporter
 
    rewind_interval = playback.locate_interval(
@@ -191,6 +192,7 @@ download progress:
        video_stream=playback.streams.query(
            "best(format eq webm and quality eq 720p)"
        ),
-       output_stem="path/to/output",
+       output_stem=Path("path/to/output"),
+       segments_directory=Path("path/to/segments"),
        progress_reporter=progress_reporter,
    )

--- a/src/ytpb/cli/commands/capture.py
+++ b/src/ytpb/cli/commands/capture.py
@@ -34,7 +34,7 @@ from ytpb.cli.common import (
 from ytpb.cli.options import (
     cache_options,
     interval_option,
-    no_cleanup_option,
+    keep_temp_option,
     preview_option,
     validate_image_output_path,
     yt_dlp_option,
@@ -180,7 +180,7 @@ def capture_group():
     callback=validate_image_output_path(CaptureOutputPathContext),
 )
 @yt_dlp_option
-@no_cleanup_option
+@keep_temp_option
 @cache_options
 @stream_argument
 @click.pass_context
@@ -190,7 +190,7 @@ def frame_command(
     video_format: str,
     output_path: Path,
     yt_dlp: bool,
-    no_cleanup: bool,
+    keep_temp: bool,
     force_update_cache: bool,
     no_cache: bool,
     stream_url: str,
@@ -296,7 +296,7 @@ def frame_command(
     click.echo(f"\nSuccess! Saved to '{saved_to_path_value}'.")
 
     run_temp_directory = playback.get_temp_directory()
-    if no_cleanup:
+    if keep_temp:
         click.echo(f"notice: No cleanup enabled, check {run_temp_directory}/")
     else:
         try:
@@ -338,7 +338,7 @@ def frame_command(
     callback=validate_image_output_path(TimelapseOutputPathContext),
 )
 @yt_dlp_option
-@no_cleanup_option
+@keep_temp_option
 @cache_options
 @stream_argument
 @click.pass_context
@@ -350,7 +350,7 @@ def timelapse_command(
     preview: bool,
     output_path: Path,
     yt_dlp: bool,
-    no_cleanup: bool,
+    keep_temp: bool,
     force_update_cache: bool,
     no_cache: bool,
     stream_url: str,
@@ -512,7 +512,7 @@ def timelapse_command(
     click.echo(f"\nSuccess! Saved to '{saved_to_path_value}/'.")
 
     run_temp_directory = playback.get_temp_directory()
-    if no_cleanup:
+    if keep_temp:
         click.echo(f"notice: No cleanup enabled, check {run_temp_directory}/")
     else:
         try:

--- a/src/ytpb/cli/commands/download.py
+++ b/src/ytpb/cli/commands/download.py
@@ -160,7 +160,7 @@ def render_download_output_path_context(
 @click.option(
     "--no-merge",
     is_flag=True,
-    help="Only download segments, without merging. Implies --keep-segments.",
+    help="Only download segments, without merging.",
 )
 @click.option("--no-resume", is_flag=True, help="Avoid resuming unfinished downloads.")
 @cache_options
@@ -567,6 +567,13 @@ def download_command(
 
             click.echo("done.\n")
             click.echo(f"Success! Saved to '{try_get_relative_path(merged_path)}'.")
+
+            if keep_segments and not preview:
+                click.echo(
+                    "~ Segments are kept in '{}'.".format(
+                        try_get_relative_path(segments_output_directory)
+                    )
+                )
 
     run_temp_directory = playback.get_temp_directory()
     if keep_temp:

--- a/src/ytpb/cli/options.py
+++ b/src/ytpb/cli/options.py
@@ -144,6 +144,6 @@ yt_dlp_option = click.option(
 )
 
 
-no_cleanup_option = click.option(
-    "--no-cleanup", is_flag=True, help="Do not clean up temporary files."
+keep_temp_option = click.option(
+    "--keep-temp", is_flag=True, help="Keep temporary files."
 )

--- a/src/ytpb/utils/path.py
+++ b/src/ytpb/utils/path.py
@@ -261,3 +261,18 @@ def format_title_for_filename(
             raise ValueError(f"Unknown title formatting style: '{style}'")
 
     return output
+
+
+def try_get_relative_path(path: Path, other: Path | None = None) -> Path:
+    try:
+        return path.relative_to(other or Path.cwd())
+    except ValueError:
+        return path
+
+
+def remove_directories_between(top: Path, until: Path) -> None:
+    until.rmdir()
+    directory = until.resolve()
+    while directory != top.resolve():
+        directory = directory.parent
+        directory.rmdir()

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -2,14 +2,24 @@
 
 import contextlib
 import os
-from collections.abc import Callable
+import sys
+from collections.abc import Callable, Sequence
 from functools import partial
 from pathlib import Path
 
 import pytest
-from click.testing import CliRunner
+from click import Command
+from click.testing import CliRunner, Result
 
 from ytpb.cli import cli
+
+
+class CustomCliRunner(CliRunner):
+    def invoke(
+        self, cli: Command, args: str | Sequence[str] | None = None, **kwargs
+    ) -> Result:
+        sys.argv = args
+        return super().invoke(cli, args, **kwargs)
 
 
 @contextlib.contextmanager
@@ -24,6 +34,6 @@ def isolated_filesystem(path: Path):
 
 @pytest.fixture()
 def ytpb_cli_invoke(tmp_path: Path) -> Callable:
-    runner = CliRunner()
+    runner = CustomCliRunner()
     with isolated_filesystem(tmp_path):
         yield partial(runner.invoke, cli)

--- a/tests/cli/test_download_command.py
+++ b/tests/cli/test_download_command.py
@@ -1541,7 +1541,7 @@ def test_resume_downloading(
         urljoin(audio_base_url, r"sq/\w+"),
     )
 
-    resume_file_stem = f"{video_id}~7959120-20230325T233359+00-140"
+    resume_file_stem = f"{video_id}_7959120-20230325T233359+00_140"
     with open(f"{resume_file_stem}.resume", "wb") as f:
         end_date = datetime.fromisoformat("2023-03-25T23:33:59+00")
         pickle.dump(
@@ -1560,11 +1560,11 @@ def test_resume_downloading(
                         is_end=True,
                     ),
                 ),
-                "segments_output_directory": Path(f"{resume_file_stem}-segments"),
+                "segments_output_directory": Path(f"{resume_file_stem}"),
             },
             f,
         )
-    segments_output_directory = tmp_path / f"{resume_file_stem}-segments"
+    segments_output_directory = tmp_path / f"{resume_file_stem}"
     segments_output_directory.mkdir()
     for segment in (7959120, 7959121):
         shutil.copy(
@@ -1601,7 +1601,7 @@ def test_resume_downloading(
     expected_path = tmp_path / "Webcam-Zurich-HB_20230325T233354+00.mp4"
     assert os.path.exists(expected_path)
     assert_approx_duration(expected_path, 6)
-    assert not os.path.exists(tmp_path / f"{resume_file_stem}-segments")
+    assert not os.path.exists(tmp_path / f"{resume_file_stem}")
 
 
 @freeze_time("2023-03-26T00:00:00+00:00")
@@ -1646,7 +1646,7 @@ def test_keep_segments(
 
     # Then:
     assert result.exit_code == 0
-    segments_directory = tmp_path / f"{video_id}~7959120-7959121-140-segments"
+    segments_directory = tmp_path / "Webcam-Zurich-HB_20230325T233354+00"
     assert os.path.exists(segments_directory / "7959120.i140.mp4")
     assert os.path.exists(segments_directory / "7959121.i140.mp4")
 
@@ -1692,7 +1692,7 @@ def test_remove_default_segments_output_directory(
 
     # Then:
     assert result.exit_code == 0
-    assert not os.path.exists(tmp_path / f"{video_id}~7959120-7959121-140-segments")
+    assert not os.path.exists(tmp_path / f"{video_id}_7959120-7959121_140")
 
 
 @pytest.mark.parametrize("segments_output_dir_option", ["a", "a/b", "./a", "../a/b"])
@@ -1770,7 +1770,7 @@ def test_remove_only_rewound_segments(
         urljoin(audio_base_url, r"sq/\w+"),
     )
 
-    segments_directory = tmp_path / f"{video_id}~7959120-7959121-segments"
+    segments_directory = tmp_path / f"{video_id}_7959120-7959121_140"
     segments_directory.mkdir()
     open(segments_directory / "0.i140.mp4", "x")
 
@@ -1913,7 +1913,7 @@ def test_no_resume_option_after_unfinished_run(
         urljoin(audio_base_url, r"sq/\w+"),
     )
 
-    resume_file_stem = f"{video_id}~7959120-7959122-140"
+    resume_file_stem = f"{video_id}_7959120-7959122_140"
     with open(f"{resume_file_stem}.resume", "wb") as f:
         pickle.dump(
             {
@@ -1931,11 +1931,11 @@ def test_no_resume_option_after_unfinished_run(
                         is_end=True,
                     ),
                 ),
-                "segments_output_directory": Path(f"{resume_file_stem}-segments"),
+                "segments_output_directory": Path(f"{resume_file_stem}"),
             },
             f,
         )
-    segments_output_directory = tmp_path / f"{resume_file_stem}-segments"
+    segments_output_directory = tmp_path / f"{resume_file_stem}"
     segments_output_directory.mkdir()
     for segment in (7959120, 7959121):
         shutil.copy(

--- a/tests/cli/test_download_command.py
+++ b/tests/cli/test_download_command.py
@@ -1541,7 +1541,7 @@ def test_resume_downloading(
         urljoin(audio_base_url, r"sq/\w+"),
     )
 
-    resume_file_stem = f"{video_id}~7959120-20230325T233359+00"
+    resume_file_stem = f"{video_id}~7959120-20230325T233359+00-140"
     with open(f"{resume_file_stem}.resume", "wb") as f:
         end_date = datetime.fromisoformat("2023-03-25T23:33:59+00")
         pickle.dump(
@@ -1646,7 +1646,7 @@ def test_keep_segments(
 
     # Then:
     assert result.exit_code == 0
-    segments_directory = tmp_path / f"{video_id}~7959120-7959121-segments"
+    segments_directory = tmp_path / f"{video_id}~7959120-7959121-140-segments"
     assert os.path.exists(segments_directory / "7959120.i140.mp4")
     assert os.path.exists(segments_directory / "7959121.i140.mp4")
 
@@ -1692,7 +1692,7 @@ def test_remove_default_segments_output_directory(
 
     # Then:
     assert result.exit_code == 0
-    assert not os.path.exists(tmp_path / f"{video_id}~7959120-7959121-segments")
+    assert not os.path.exists(tmp_path / f"{video_id}~7959120-7959121-140-segments")
 
 
 @pytest.mark.parametrize("segments_output_dir_option", ["a", "a/b", "./a", "../a/b"])
@@ -1913,7 +1913,7 @@ def test_no_resume_option_after_unfinished_run(
         urljoin(audio_base_url, r"sq/\w+"),
     )
 
-    resume_file_stem = f"{video_id}~7959120-7959122"
+    resume_file_stem = f"{video_id}~7959120-7959122-140"
     with open(f"{resume_file_stem}.resume", "wb") as f:
         pickle.dump(
             {

--- a/tests/data/expected/test_no_merge_option.out
+++ b/tests/data/expected/test_no_merge_option.out
@@ -11,4 +11,4 @@ Actual start: 25 Mar 2023 23:33:54 +0000, seq. 7959120
 (<<) Downloading segments 7959120-7959121 (no merge requested)...
    - Audio ━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 100% eta 0:00:00
 
-Success! Segments saved to kHwmzef842g~7959120-7959121-segments/.
+Success! Segments saved to kHwmzef842g~7959120-7959121-140-segments/.

--- a/tests/data/expected/test_no_merge_option.out
+++ b/tests/data/expected/test_no_merge_option.out
@@ -11,4 +11,4 @@ Actual start: 25 Mar 2023 23:33:54 +0000, seq. 7959120
 (<<) Downloading segments 7959120-7959121 (no merge requested)...
    - Audio ━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 100% eta 0:00:00
 
-Success! Segments saved to kHwmzef842g~7959120-7959121-140-segments/.
+Success! Segments saved to Webcam-Zurich-HB_20230325T233354+00/.

--- a/tests/data/expected/test_no_merge_option.out
+++ b/tests/data/expected/test_no_merge_option.out
@@ -11,5 +11,4 @@ Actual start: 25 Mar 2023 23:33:54 +0000, seq. 7959120
 (<<) Downloading segments 7959120-7959121 (no merge requested)...
    - Audio ━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 100% eta 0:00:00
 
-Success! Segments saved to /tmp/pytest-of-ms/pytest-1/test_no_merge_option0/tmpnghtuj8q/segments/.
-notice: No cleanup enabled, check /tmp/pytest-of-ms/pytest-1/test_no_merge_option0/tmpnghtuj8q/
+Success! Segments saved to kHwmzef842g~7959120-7959121-segments/.


### PR DESCRIPTION
This PR adds support for resumable downloads via resume files to `ytpb download`. Could be useful to continue unfinished downloads by execution of the interrupted commands again.

Each run creates a resume file used to keep information needed for resumption, which is cleaned after successful completion. The commands are matched based on the following input option values: `--interval`, `--audio-format`, `--video-format`, and `--segments-output-dir`. 

Also, media segments are now downloaded to a segments output directory under the current working directory instead of the run temporary directory (if no other one is specified via `--segments-output-dir`).

Additionally, the following options were added:

* `--no-resume`: To avoid creating a resume file and continuing an unfinished download
* `--keep-segments`: To keep download segments after merging
* `--segments-output-dir`:  To specify a location where to download segments to
* `--keep-temp`:  To keep temporary files. Renamed from `--no-cleanup`
