### PR TITLE
Add option to ignore existing resume files and start from scratch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,8 @@ Versions follow `Calendar Versioning`_ with the ``YYYY.M.D`` scheme.
 - Download media segments to a segments output directory under the current
   working one instead of the run temporary directory (`#13
   <https://github.com/xymaxim/ytpb/pull/13>`__)
-- Add ``--no-resume``, ``-S / --keep-segments``, and ``--segments-output-dir``
-  options
+- Add ``--ignore-resume``, ``-S / --keep-segments``, and
+  ``--segments-output-dir`` options
 - Rename the ``--no-cleanup`` option to ``--keep-temp``
 - Change the default output path to ``<title>_<id>_<input_start_date>``
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -592,8 +592,8 @@ used to keep information needed for resumption, which is cleaned after
 successful completion. The commands are matched based on the following input
 option values: ``--interval``, ``--audio-format``, ``--video-format``, and
 ``--segments-output-dir``. Resuming behavior can be disabled by the
-``--no-resume`` option to avoid: (1) creating a resume file at all and (2)
-continuing an existing download.
+``--ignore-resume`` option to avoid using an existing resume file and start
+download from scratch.
 
 .. _Configuring:
 

--- a/tests/cli/test_download_command.py
+++ b/tests/cli/test_download_command.py
@@ -1856,7 +1856,7 @@ def test_do_not_remove_existing_directory(
 
 
 @freeze_time("2023-03-26T00:00:00+00:00")
-def test_no_resume_option(
+def test_ignore_resume_option(
     ytpb_cli_invoke: Callable,
     add_responses_callback_for_reference_base_url: Callable,
     add_responses_callback_for_segment_urls: Callable,
@@ -1882,7 +1882,7 @@ def test_no_resume_option(
                 "download",
                 "--no-cache",
                 "--no-cut",
-                "--no-resume",
+                "--ignore-resume",
                 "--interval",
                 "7959120/7959121",
                 "-af",
@@ -1900,7 +1900,7 @@ def test_no_resume_option(
 
 
 @freeze_time("2023-03-26T00:00:00+00:00")
-def test_no_resume_option_after_unfinished_run(
+def test_ignore_resume_option_after_unfinished_run(
     ytpb_cli_invoke: Callable,
     add_responses_callback_for_reference_base_url: Callable,
     add_responses_callback_for_segment_urls: Callable,
@@ -1956,7 +1956,10 @@ def test_no_resume_option_after_unfinished_run(
                 "download",
                 "--no-cache",
                 "--no-cut",
-                "--no-resume",
+                "--ignore-resume",
+                "--segments-output-dir",
+                "segments",
+                "--keep-segments",
                 "--interval",
                 "7959120/7959122",
                 "-af",
@@ -1971,4 +1974,5 @@ def test_no_resume_option_after_unfinished_run(
 
     # Then:
     assert result.exit_code == 0
-    assert os.path.exists(f"{resume_file_stem}.resume")
+    assert os.path.exists(tmp_path / f"{video_id}_7959120-7959122_140")
+    assert os.path.exists(tmp_path / "segments")


### PR DESCRIPTION
This PR adds a new option called ``--ignore-resume`` instead of ``--no-resume`` (see #13). It seems that it doesn't make much sense not to create resume files at all. What's better is to have an option just to avoid resuming an unfinished run and start a new one from scratch. 