### PR TITLE
Add support for date and time arithmetic for interval dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Versions follow [Calendar Versioning](https://calver.org) with the `YYYY.M.D`
 scheme.
 
 
+## [2024.12.23]
+
+- Allow date and time arithmetic for dates in `--interval`
+  ([#30](https://github.com/xymaxim/ytpb/issues/30))
+
 ## [2024.9.9]
 
 - Build Windows binary without `--noconsole` that caused no output in console
@@ -124,6 +129,7 @@ scheme.
 - Change the first segment locating step: don\'t limit it to two jumps
   ([#8](https://github.com/xymaxim/ytpb/pull/8))
 
+[2024.12.23]: https://github.com/xymaxim/ytpb/compare/v2024.9.9...v2024.12.23
 [2024.9.9]: https://github.com/xymaxim/ytpb/compare/v2024.9.8...v2024.9.9
 [2024.9.8]: https://github.com/xymaxim/ytpb/compare/v2024.6.13...v2024.9.8
 [2024.6.13]: https://github.com/xymaxim/ytpb/compare/v2024.5.30...v2024.6.13

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -121,7 +121,9 @@ where ``<date-time> = <date>"T"<time>"±"<shift>``:
 
 The extended (I) and basic (II) formats are supported.
 
-For example, an interval with two complete date and time representations: ::
+For example, an interval with two complete date and time representations:
+
+.. code:: sh
 
   # Complete representations in extended format
   $ ytpb download -i 2024-01-02T10:20:00+00/2024-01-02T10:20:30+00 ...
@@ -130,7 +132,9 @@ For example, an interval with two complete date and time representations: ::
   $ ytpb download -i 20240102T102000+00/20240102T102030+00 ...
 
 The time part can be also provided with a reduced precision, with some low-order
-components omitted (the date part should be always complete): ::
+components omitted (the date part should be always complete):
+
+.. code:: sh
 
   # Representations with reduced precision in extended format
   $ ytpb download -i 2024-01-02T1020+00/2024-01-02T10:20:30+00 ...
@@ -211,16 +215,18 @@ substitution. For example, this expression ``2024-12-13T10:20:30 - P1DT30S``
 results in ``2024-12-12T10:20:00``. Note that the option value needs to be quoted
 to handle whitespaces.
 
-Some examples: ::
+Some examples:
+
+.. code:: sh
 
   # Subtraction between date and duration
-  $ ytpb download -i "2024-12-13T10:20:30 - P1DT30S/PT30S" ...
+  $ ytpb download -i '2024-12-13T10:20:30 - P1DT30S/PT30S' ...
 
   # Download an excerpt around some specific time
-  $ ytpb download -i "12:00 - PT1M/12:00 + PT5M"
+  $ ytpb download -i '12:00 - PT1M/12:00 + PT5M'
 
   # Download an excerpt between 23:00 and 01:00
-  $ ytpb download -i "23:00 - P1D/01:00" ...
+  $ ytpb download -i '23:00 - P1D/01:00' ...
 
 B. Using duration
 -----------------
@@ -238,7 +244,9 @@ The duration string is prepended with "P" symbol and used one-letter date and
 time component designators. The highest order of date components is days ("D").
 
 For example, here are below two examples representing the same 30-second
-interval: ::
+interval:
+
+.. code:: sh
 
   # Specified by a start and a duration
   $ ytpb download -i 2024-01-02T10:20:00+00/PT30S ...
@@ -276,7 +284,7 @@ D. Using keywords
 * ``-i/--interval earliest/<end>``
 
 To refer to the earliest available moment, the start part accepts the ``earliest``
-keyword::
+keyword: ::
 
   $ ytpb download -i earliest/PT30S ...
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -191,11 +191,36 @@ to change are supplied: ::
 
 * ``--interval <timestamp>/<timestamp>``
 
-where ``<timestamp> = "@"<epoch-seconds>``:
+where ``<timestamp> = "@"<epoch-seconds>``.
 
 The date and time interval can also be specified with Unix timestamps as: ::
 
    $ ytpb download -i @1704190800/@1704190830 ...
+
+*Date and time arithmetic*
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* ``--interval <expression>/<expression>``
+
+where ``<expression> = <operand> "±" <duration>`` or ``<expression> = <duration>
+"+" <operand>``, and ``<operand> = <date-time> or <time>``.
+
+Input dates can be represented as arithmetic expressions between dates (or
+times) and (positive) durations. Such temporal arithmetic supports addition and
+substitution. For example, this expression ``2024-12-13T10:20:30 - P1DT30S``
+results in ``2024-12-12T10:20:00``. Note that the option value needs to be quoted
+to handle whitespaces.
+
+Some examples: ::
+
+  # Subtraction between date and duration
+  $ ytpb download -i "2024-12-13T10:20:30 - P1DT30S/PT30S" ...
+
+  # Download an excerpt around some specific time
+  $ ytpb download -i "12:00 - PT1M/12:00 + PT5M"
+
+  # Download an excerpt between 23:00 and 01:00
+  $ ytpb download -i "23:00 - P1D/01:00" ...
 
 B. Using duration
 -----------------

--- a/tests/cli/test_download_command.py
+++ b/tests/cli/test_download_command.py
@@ -46,6 +46,7 @@ freezegun.api.FakeDatetime.astimezone = patched_freezgun_astimezone
         ("PT3S/7959121", "233355+00.mp4"),
         ("PT3S/2023-03-25T23:33:58+00", "233355+00.mp4"),
         ("2023-03-26T01:33:55/7959121", "013355+02.mp4"),
+        ("2023-03-25T23:33:50+00 + PT5S/7959121", "233355+00.mp4"),
     ],
 )
 @pytest.mark.expect_suffix(platform.system())

--- a/tests/cli/test_parameters.py
+++ b/tests/cli/test_parameters.py
@@ -100,6 +100,27 @@ def test_format_spec_without_function():
         ),
         ("earliest/100", ("earliest", 100)),
         ("earliest/..", ("earliest", "..")),
+        (
+            "20240102T102030+00 - P1DT1H20M30S/..",
+            (
+                datetime(2024, 1, 1, 9, 0, 0, tzinfo=timezone.utc),
+                "..",
+            ),
+        ),
+        (
+            "20240102T102030+00 + P1DT1H20M30S/..",
+            (
+                datetime(2024, 1, 3, 11, 41, 0, tzinfo=timezone.utc),
+                "..",
+            ),
+        ),
+        (
+            "P1DT1H20M30S + 20240102T102030+00/..",
+            (
+                datetime(2024, 1, 3, 11, 41, 0, tzinfo=timezone.utc),
+                "..",
+            ),
+        ),
     ],
 )
 def test_rewind_interval(value: str, expected):
@@ -149,6 +170,13 @@ def test_rewind_interval_with_replacing_components(value: str, expected):
             (
                 FakeDatetime(2024, 1, 2, 10, 25, tzinfo=tzlocal()),
                 FakeDatetime(2024, 1, 2, 10, 35, tzinfo=tzlocal()),
+            ),
+        ),
+        (
+            "10:25 + PT1M/T1035 - PT1M",
+            (
+                FakeDatetime(2024, 1, 2, 10, 26, 0, tzinfo=tzlocal()),
+                FakeDatetime(2024, 1, 2, 10, 34, 0, tzinfo=tzlocal()),
             ),
         ),
     ],

--- a/tests/data/expected/test_download_within_interval[2023-03-25T23%3A33%3A50%2B00%20%2B%20PT5S%2F7959121-233355%2B00.mp4]-Linux.out
+++ b/tests/data/expected/test_download_within_interval[2023-03-25T23%3A33%3A50%2B00%20%2B%20PT5S%2F7959121-233355%2B00.mp4]-Linux.out
@@ -1,0 +1,16 @@
+Run playback for https://www.youtube.com/watch?v=kHwmzef842g
+(<<) Collecting info about the video...
+Stream 'Webcam Zürich HB' is alive!
+This representation will be downloaded:
+   - Audio: itag 140, mp4 (mp4a.40.2), 44100 Hz
+
+(<<) Locating start and end in the stream... done.
+Actual start: 25 Mar 2023 23:33:54 +0000 (-00:01), seq. 7959120
+  Actual end: 25 Mar 2023 23:33:58 +0000, seq. 7959121
+
+(<<) Preparing and saving the excerpt...
+1. Downloading segments 7959120-7959121:
+   - Audio ━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2/2 100% eta 0:00:00
+2. Merging segments (may take a while)... done.
+
+Success! Saved to 'Webcam-Zurich-HB_kHwmzef842g_20230325T233355+00.mp4'.


### PR DESCRIPTION
Closes #29.

This adds support for the basic date and time arithmetic used to represent input interval dates. Only positive durations are allowed.

Some examples:

```sh
  # Subtraction between date and duration
  $ ytpb download -i '2024-12-13T10:20:30 - P1DT30S/PT30S' ...

  # Download an excerpt around some specific time
  $ ytpb download -i '12:00 - PT1M/12:00 + PT5M'

  # Download an excerpt between 23:00 and 01:00
  $ ytpb download -i '23:00 - P1D/01:00' ...
```